### PR TITLE
Transaction resolve keyspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "bytes",
  "common",
  "epoch_reader",
+ "proto",
  "rangeclient",
  "strum",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "strum",
  "tokio",
  "tokio-util",
+ "tonic",
  "tx_state_store",
  "uuid 1.10.0",
 ]

--- a/common/src/keyspace_id.rs
+++ b/common/src/keyspace_id.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Hash)]
@@ -8,5 +9,13 @@ pub struct KeyspaceId {
 impl KeyspaceId {
     pub fn new(id: Uuid) -> KeyspaceId {
         KeyspaceId { id }
+    }
+}
+
+impl FromStr for KeyspaceId {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let id = Uuid::parse_str(s).map_err(|_| "Invalid UUID".to_string())?;
+        Ok(KeyspaceId { id })
     }
 }

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.7.2"
+proto = { version = "0.1.0", path = "../proto" }
 common = { version = "0.1.0", path = "../common" }
 epoch_reader = { version = "0.1.0", path = "../epoch_reader" }
 rangeclient = { version = "0.1.0", path = "../rangeclient" }

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -16,3 +16,4 @@ tokio = "1.40.0"
 tokio-util = "0.7.10"
 tx_state_store = { version = "0.1.0", path = "../tx_state_store" }
 uuid = "1.10.0"
+tonic = "0.11.0"

--- a/coordinator/src/coordinator.rs
+++ b/coordinator/src/coordinator.rs
@@ -11,6 +11,7 @@ use tx_state_store::client::Client as TxStateStoreClient;
 use crate::transaction::Transaction;
 
 pub struct Coordinator {
+    config: Config,
     range_assignment_oracle: Arc<dyn RangeAssignmentOracle>,
     runtime: tokio::runtime::Handle,
     range_client: Arc<crate::rangeclient::RangeClient>,
@@ -50,6 +51,7 @@ impl Coordinator {
             cancellation_token.clone(),
         ));
         Coordinator {
+            config: config.clone(),
             range_assignment_oracle,
             runtime,
             range_client,
@@ -61,6 +63,7 @@ impl Coordinator {
     pub fn start_transaction(&self, transaction_info: Arc<TransactionInfo>) -> Transaction {
         //TODO(tamer): start transaction at the tx_state_store.
         Transaction::new(
+            self.config.clone(),
             transaction_info,
             self.range_client.clone(),
             self.range_assignment_oracle.clone(),

--- a/coordinator/src/coordinator.rs
+++ b/coordinator/src/coordinator.rs
@@ -5,13 +5,14 @@ use common::{
     network::fast_network::FastNetwork, region::Zone, transaction_info::TransactionInfo,
 };
 use epoch_reader::reader::EpochReader;
+use proto::universe::universe_client::UniverseClient;
 use tokio_util::sync::CancellationToken;
 use tx_state_store::client::Client as TxStateStoreClient;
 
 use crate::transaction::Transaction;
 
 pub struct Coordinator {
-    config: Config,
+    universe_client: UniverseClient<tonic::transport::Channel>,
     range_assignment_oracle: Arc<dyn RangeAssignmentOracle>,
     runtime: tokio::runtime::Handle,
     range_client: Arc<crate::rangeclient::RangeClient>,
@@ -50,8 +51,11 @@ impl Coordinator {
             publisher_set.clone(),
             cancellation_token.clone(),
         ));
+        let universe_addr = format!("http://{}", config.universe.proto_server_addr.to_string());
+        let universe_client = UniverseClient::connect(universe_addr).await.unwrap();
+
         Coordinator {
-            config: config.clone(),
+            universe_client,
             range_assignment_oracle,
             runtime,
             range_client,
@@ -63,8 +67,8 @@ impl Coordinator {
     pub fn start_transaction(&self, transaction_info: Arc<TransactionInfo>) -> Transaction {
         //TODO(tamer): start transaction at the tx_state_store.
         Transaction::new(
-            self.config.clone(),
             transaction_info,
+            self.universe_client.clone(),
             self.range_client.clone(),
             self.range_assignment_oracle.clone(),
             self.epoch_reader.clone(),

--- a/coordinator/src/transaction.rs
+++ b/coordinator/src/transaction.rs
@@ -70,7 +70,6 @@ impl Transaction {
         if let Some(k) = self.resolved_keyspaces.get(keyspace) {
             return Ok(*k);
         };
-        // TODO(tamer): implement proper resolution from universe.
         let keyspace_info_request = GetKeyspaceInfoRequest {
             keyspace_info_search_field: Some(KeyspaceInfoSearchField::Keyspace(ProtoKeyspace {
                 namespace: keyspace.namespace.clone(),

--- a/proto/src/universe.proto
+++ b/proto/src/universe.proto
@@ -4,6 +4,7 @@ package universe;
 service Universe {
     rpc CreateKeyspace (CreateKeyspaceRequest) returns (CreateKeyspaceResponse);
     rpc ListKeyspaces (ListKeyspacesRequest) returns (ListKeyspacesResponse);
+    rpc GetKeyspaceInfo (GetKeyspaceInfoRequest) returns (GetKeyspaceInfoResponse);
 }
 
 enum Cloud {
@@ -62,4 +63,19 @@ message ListKeyspacesRequest {
 
 message ListKeyspacesResponse {
     repeated KeyspaceInfo keyspaces = 1;
+}
+
+message Keyspace {
+    string namespace = 1;
+    string name = 2;
+}
+message GetKeyspaceInfoRequest {
+    oneof keyspace_info_search_field {
+        Keyspace keyspace = 1;
+        string keyspace_id = 2;
+    }
+}
+
+message GetKeyspaceInfoResponse {
+    KeyspaceInfo keyspace_info = 1;
 }

--- a/universe/src/storage.rs
+++ b/universe/src/storage.rs
@@ -1,4 +1,7 @@
-use proto::universe::{KeyRange, KeyspaceInfo, Zone};
+use proto::universe::{
+    get_keyspace_info_request::KeyspaceInfoSearchField as ProtoKeyspaceInfoSearchField, KeyRange,
+    Keyspace, KeyspaceInfo, Zone,
+};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -12,6 +15,41 @@ pub enum Error {
     KeyspaceAlreadyExists,
     #[error("Storage Layer error: {}", .0.as_ref().map(|e| e.to_string()).unwrap_or_else(|| "Unknown error".to_string()))]
     InternalError(Option<Arc<dyn std::error::Error + Send + Sync>>),
+    #[error("Keyspace does not exist")]
+    KeyspaceDoesNotExist,
+}
+
+#[derive(Debug)]
+pub enum KeyspaceInfoSearchField {
+    Keyspace { namespace: String, name: String },
+    KeyspaceId(String),
+}
+
+impl From<ProtoKeyspaceInfoSearchField> for KeyspaceInfoSearchField {
+    fn from(val: ProtoKeyspaceInfoSearchField) -> Self {
+        match val {
+            ProtoKeyspaceInfoSearchField::Keyspace(keyspace) => KeyspaceInfoSearchField::Keyspace {
+                namespace: keyspace.namespace,
+                name: keyspace.name,
+            },
+            ProtoKeyspaceInfoSearchField::KeyspaceId(keyspace_id) => {
+                KeyspaceInfoSearchField::KeyspaceId(keyspace_id)
+            }
+        }
+    }
+}
+
+impl From<KeyspaceInfoSearchField> for ProtoKeyspaceInfoSearchField {
+    fn from(val: KeyspaceInfoSearchField) -> Self {
+        match val {
+            KeyspaceInfoSearchField::Keyspace { namespace, name } => {
+                ProtoKeyspaceInfoSearchField::Keyspace(Keyspace { namespace, name })
+            }
+            KeyspaceInfoSearchField::KeyspaceId(keyspace_id) => {
+                ProtoKeyspaceInfoSearchField::KeyspaceId(keyspace_id)
+            }
+        }
+    }
 }
 
 pub trait Storage: Send + Sync + 'static {
@@ -28,4 +66,9 @@ pub trait Storage: Send + Sync + 'static {
         &self,
         region: Option<proto::universe::Region>,
     ) -> impl std::future::Future<Output = Result<Vec<KeyspaceInfo>, Error>> + Send;
+
+    fn get_keyspace_info(
+        &self,
+        keyspace_info_search_field: KeyspaceInfoSearchField,
+    ) -> impl std::future::Future<Output = Result<KeyspaceInfo, Error>> + Send;
 }

--- a/warden/src/assignment_computation.rs
+++ b/warden/src/assignment_computation.rs
@@ -457,7 +457,8 @@ mod tests {
     use once_cell::sync::Lazy;
     use proto::universe::{
         universe_server::{Universe, UniverseServer},
-        CreateKeyspaceRequest, CreateKeyspaceResponse, KeyspaceInfo, ListKeyspacesResponse,
+        CreateKeyspaceRequest, CreateKeyspaceResponse, GetKeyspaceInfoRequest,
+        GetKeyspaceInfoResponse, KeyspaceInfo, ListKeyspacesResponse,
     };
     use scylla::{Session, SessionBuilder};
     use tokio::sync::oneshot;
@@ -555,6 +556,13 @@ mod tests {
                         .collect(),
                 }],
             }))
+        }
+
+        async fn get_keyspace_info(
+            &self,
+            _request: Request<GetKeyspaceInfoRequest>,
+        ) -> Result<Response<GetKeyspaceInfoResponse>, Status> {
+            unreachable!()
         }
     }
 


### PR DESCRIPTION
An implementation for `Transaction::resolve_keyspace`.
Changes:
- Extended the API of the`Universe` with `get_keyspace_info` which takes either a `Keyspace` or a `KeyspaceId` and returns the `KeyspaceInfo`of a keyspace.
- The `Transaction::resolve_keyspace` now  connects with the `Universe` and fetches the `KeyspaceInfo::KeyspaceId` using the extended API.
- Updated `Warden`'s `MockUniverse`to work with the new `Universe` changes.