### PR TITLE
WIP: Frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "bytes",
  "common",
  "epoch_reader",
+ "proto",
  "rangeclient",
  "strum",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "frontend"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "common",
+ "coordinator",
+ "once_cell",
+ "portpicker",
+ "prost",
+ "proto",
+ "scylla 0.13.2",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+ "universe",
+ "uuid 1.10.0",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["common", "coordinator", "epoch", "epoch_publisher", "epoch_reader", "flatbuf", "proto", "rangeclient", "rangeserver", "tx_state_store", "warden", "universe"]
+members = ["common", "coordinator", "epoch", "epoch_publisher", "epoch_reader", "flatbuf", "proto", "rangeclient", "rangeserver", "tx_state_store", "warden", "universe", "frontend"]
 
 [workspace.dependencies]
 test-case = "3"

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -126,10 +126,18 @@ pub struct UniverseConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FrontendConfig {
+    pub proto_server_addr: HostPort,
+    pub fast_network_addr: HostPort,
+    pub transaction_overall_timeout: std::time::Duration,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
     pub range_server: RangeServerConfig,
     pub epoch: EpochConfig,
     pub universe: UniverseConfig,
+    pub frontend: FrontendConfig,
     pub cassandra: CassandraConfig,
     pub regions: HashMap<Region, RegionConfig>,
 }

--- a/common/src/keyspace_id.rs
+++ b/common/src/keyspace_id.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Hash)]
@@ -8,5 +9,13 @@ pub struct KeyspaceId {
 impl KeyspaceId {
     pub fn new(id: Uuid) -> KeyspaceId {
         KeyspaceId { id }
+    }
+}
+
+impl FromStr for KeyspaceId {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let id = Uuid::parse_str(s).map_err(|_| "Invalid UUID".to_string())?;
+        Ok(KeyspaceId { id })
     }
 }

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.7.2"
+proto = { version = "0.1.0", path = "../proto" }
 common = { version = "0.1.0", path = "../common" }
 epoch_reader = { version = "0.1.0", path = "../epoch_reader" }
 rangeclient = { version = "0.1.0", path = "../rangeclient" }

--- a/coordinator/src/coordinator.rs
+++ b/coordinator/src/coordinator.rs
@@ -11,6 +11,7 @@ use tx_state_store::client::Client as TxStateStoreClient;
 use crate::transaction::Transaction;
 
 pub struct Coordinator {
+    config: Config,
     range_assignment_oracle: Arc<dyn RangeAssignmentOracle>,
     runtime: tokio::runtime::Handle,
     range_client: Arc<crate::rangeclient::RangeClient>,
@@ -50,6 +51,7 @@ impl Coordinator {
             cancellation_token.clone(),
         ));
         Coordinator {
+            config: config.clone(),
             range_assignment_oracle,
             runtime,
             range_client,
@@ -61,6 +63,7 @@ impl Coordinator {
     pub fn start_transaction(&self, transaction_info: Arc<TransactionInfo>) -> Transaction {
         //TODO(tamer): start transaction at the tx_state_store.
         Transaction::new(
+            self.config.clone(),
             transaction_info,
             self.range_client.clone(),
             self.range_assignment_oracle.clone(),

--- a/epoch_publisher/tests/integration_tests.rs
+++ b/epoch_publisher/tests/integration_tests.rs
@@ -13,8 +13,8 @@ use tokio_util::sync::CancellationToken;
 
 use common::{
     config::{
-        CassandraConfig, Config, EpochConfig, EpochPublisher as EpochPublisherConfig, HostPort,
-        RangeServerConfig, RegionConfig, FrontendConfig, UniverseConfig,
+        CassandraConfig, Config, EpochConfig, EpochPublisher as EpochPublisherConfig,
+        FrontendConfig, HostPort, RangeServerConfig, RegionConfig, UniverseConfig,
     },
     host_info::{HostIdentity, HostInfo},
     network::{fast_network::FastNetwork, for_testing::udp_fast_network::UdpFastNetwork},

--- a/epoch_publisher/tests/integration_tests.rs
+++ b/epoch_publisher/tests/integration_tests.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use common::{
     config::{
         CassandraConfig, Config, EpochConfig, EpochPublisher as EpochPublisherConfig, HostPort,
-        RangeServerConfig, RegionConfig, UniverseConfig,
+        RangeServerConfig, RegionConfig, FrontendConfig, UniverseConfig,
     },
     host_info::{HostIdentity, HostInfo},
     network::{fast_network::FastNetwork, for_testing::udp_fast_network::UdpFastNetwork},
@@ -53,6 +53,11 @@ fn get_config(epoch_address: SocketAddr) -> Config {
         },
         universe: UniverseConfig {
             proto_server_addr: "127.0.0.1:123".parse().unwrap(),
+        },
+        frontend: FrontendConfig {
+            proto_server_addr: HostPort::from_str("127.0.0.1:50057").unwrap(),
+            fast_network_addr: HostPort::from_str("127.0.0.1:50058").unwrap(),
+            transaction_overall_timeout: time::Duration::from_secs(10),
         },
         cassandra: CassandraConfig {
             cql_addr: "127.0.0.1:9042".parse().unwrap(),

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "frontend"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+common = { version = "0.1.0", path = "../common" }
+coordinator = { version = "0.1.0", path = "../coordinator"}
+universe = { version = "0.1.0", path = "../universe"}
+bytes = "1.7.2"
+proto = {path = "../proto"}
+strum = "0.26.3"
+tokio = "1.40.0"
+tokio-util = "0.7.10"
+tokio-stream = { version="0.1.15", features = ["sync"]}
+uuid = "1.10.0"
+async-trait = "0.1.82"
+serde = "1.0.210"
+serde_json = "1.0.128"
+tonic = "0.11.0"
+tracing = "0.1.40"
+prost = "0.12"
+tracing-subscriber = "0.3.18"
+chrono = "0.4"
+scylla = "0.13.2"
+portpicker = "0.1.1"
+once_cell = "1.19.0"

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,0 +1,5 @@
+// pub mod client;
+// pub mod error;
+pub mod range_assignment_oracle;
+// pub mod frontend;
+// pub mod for_testing;

--- a/frontend/src/range_assignment_oracle.rs
+++ b/frontend/src/range_assignment_oracle.rs
@@ -1,0 +1,260 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use uuid::Uuid;
+
+use common::membership::range_assignment_oracle::RangeAssignmentOracle as RangeAssignmentOracleTrait;
+use common::{full_range_id::FullRangeId, host_info::HostInfo, keyspace_id::KeyspaceId};
+
+use proto::universe::universe_client::UniverseClient;
+use proto::universe::{get_keyspace_info_request::KeyspaceInfoSearchField, GetKeyspaceInfoRequest};
+
+// TODO: Dumb little Oracle -- redesign it
+
+pub struct RangeAssignmentOracle {
+    universe_client: UniverseClient<tonic::transport::Channel>,
+}
+
+impl RangeAssignmentOracle {
+    pub fn new(universe_client: UniverseClient<tonic::transport::Channel>) -> Self {
+        RangeAssignmentOracle { universe_client }
+    }
+}
+
+#[async_trait]
+impl RangeAssignmentOracleTrait for RangeAssignmentOracle {
+    async fn full_range_id_of_key(
+        &self,
+        keyspace_id: KeyspaceId,
+        key: Bytes,
+    ) -> Option<FullRangeId> {
+        // TODO: Pretty slow way of resolving the range id -- optimize this
+        // Get KeyspaceInfo by keyspace_id from universe client
+        // First,we have already fetched the keyspace_info in Transaction::resolve_keyspace so this is redundant
+        // second, we do linear search through the base ranges of keyspace_info to find the range_id which is inefficient
+
+        //  TODO: Change return type to Result<FullRangeId, Error> and do better error handling
+        let keyspace_info_request = GetKeyspaceInfoRequest {
+            keyspace_info_search_field: Some(KeyspaceInfoSearchField::KeyspaceId(
+                keyspace_id.id.to_string(),
+            )),
+        };
+        let mut client = self.universe_client.clone();
+        let keyspace_info_response = client
+            .get_keyspace_info(keyspace_info_request)
+            .await
+            .unwrap();
+
+        let keyspace_info = keyspace_info_response.into_inner().keyspace_info.unwrap();
+
+        for range in keyspace_info.base_key_ranges {
+            if range.lower_bound_inclusive <= key && key < range.upper_bound_exclusive {
+                return Some(FullRangeId {
+                    keyspace_id,
+                    range_id: Uuid::parse_str(&range.base_range_uuid).unwrap(),
+                });
+            }
+        }
+        None
+    }
+
+    async fn host_of_range(&self, range_id: &FullRangeId) -> Option<HostInfo> {
+        //  Ask warden for the host of the range
+        todo!()
+    }
+    fn maybe_refresh_host_of_range(&self, range_id: &FullRangeId) {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use proto::universe::universe_client::UniverseClient;
+    use proto::universe::{
+        universe_server::{Universe, UniverseServer},
+        CreateKeyspaceRequest, CreateKeyspaceResponse, GetKeyspaceInfoRequest,
+        GetKeyspaceInfoResponse, KeyRange as ProtoKeyRange, KeyspaceInfo, ListKeyspacesRequest,
+        ListKeyspacesResponse, Region as ProtoRegion, Zone as ProtoZone,
+    };
+    use scylla::{Session, SessionBuilder};
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::oneshot;
+    use tokio_util::sync::CancellationToken;
+    use tonic::{Request, Response, Status};
+    use tracing::info;
+    use uuid::Uuid;
+
+    fn make_zone() -> ProtoZone {
+        ProtoZone {
+            region: Some(ProtoRegion {
+                cloud: None,
+                name: "test".to_string(),
+            }),
+            name: "test_zone".to_string(),
+        }
+    }
+
+    fn make_keyspaceinfo(name: String, namespace: String) -> KeyspaceInfo {
+        KeyspaceInfo {
+            keyspace_id: Uuid::new_v4().to_string(),
+            name: name,
+            namespace: namespace,
+            primary_zone: Some(make_zone()),
+            base_key_ranges: vec![ProtoKeyRange {
+                lower_bound_inclusive: vec![0],
+                upper_bound_exclusive: vec![10],
+                base_range_uuid: Uuid::new_v4().to_string(),
+            }],
+        }
+    }
+
+    struct MockUniverseService {
+        keyspaces_info: Arc<Mutex<Vec<KeyspaceInfo>>>,
+    }
+
+    #[tonic::async_trait]
+    impl Universe for MockUniverseService {
+        async fn create_keyspace(
+            &self,
+            _: Request<CreateKeyspaceRequest>,
+        ) -> Result<Response<CreateKeyspaceResponse>, Status> {
+            unreachable!()
+        }
+
+        async fn list_keyspaces(
+            &self,
+            _request: Request<ListKeyspacesRequest>,
+        ) -> Result<Response<ListKeyspacesResponse>, Status> {
+            unreachable!()
+        }
+
+        async fn get_keyspace_info(
+            &self,
+            _request: Request<GetKeyspaceInfoRequest>,
+        ) -> Result<Response<GetKeyspaceInfoResponse>, Status> {
+            let keyspace_info_search_field =
+                _request.into_inner().keyspace_info_search_field.unwrap();
+            match keyspace_info_search_field {
+                KeyspaceInfoSearchField::KeyspaceId(keyspace_id) => {
+                    //  search keyspaces until we find the one with the same keyspace_id
+                    for keyspace_info in self.keyspaces_info.lock().unwrap().iter() {
+                        if keyspace_info.keyspace_id == keyspace_id {
+                            return Ok(Response::new(GetKeyspaceInfoResponse {
+                                keyspace_info: Some(keyspace_info.clone()),
+                            }));
+                        }
+                    }
+                }
+                _ => {
+                    return Err(Status::invalid_argument(
+                        "Invalid keyspace info search field",
+                    ));
+                }
+            }
+            Err(Status::not_found("Keyspace not found"))
+        }
+    }
+
+    static RUNTIME: Lazy<tokio::runtime::Runtime> =
+        Lazy::new(|| tokio::runtime::Runtime::new().unwrap());
+
+    struct TestContext {
+        range_assignment_oracle: Arc<RangeAssignmentOracle>,
+        server_shutdown_tx: Option<oneshot::Sender<()>>,
+        keyspaces_info: Arc<Mutex<Vec<KeyspaceInfo>>>,
+        session: Arc<Session>,
+        cancellation_token: CancellationToken,
+    }
+
+    impl Drop for TestContext {
+        fn drop(&mut self) {
+            let _ = self.server_shutdown_tx.take().unwrap().send(());
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }
+
+    async fn setup() -> TestContext {
+        let port = portpicker::pick_unused_port().unwrap();
+        let addr = format!("[::1]:{port}").parse().unwrap();
+        let cancellation_token = CancellationToken::new();
+        let (signal_tx, signal_rx) = oneshot::channel();
+        let keyspaces_info = Arc::new(Mutex::new(vec![]));
+        let keyspaces_info_clone = keyspaces_info.clone();
+        let cc_clone = cancellation_token.clone();
+        RUNTIME.spawn(async move {
+            let universe_server = MockUniverseService {
+                keyspaces_info: keyspaces_info_clone,
+            };
+            tonic::transport::Server::builder()
+                .add_service(UniverseServer::new(universe_server))
+                .serve_with_shutdown(addr, async {
+                    signal_rx.await.ok();
+                    cancellation_token.cancel();
+                    info!("Server shutting down");
+                })
+                .await
+                .unwrap();
+
+            info!("Server task completed");
+        });
+        let client: UniverseClient<tonic::transport::Channel>;
+        let addr_string = format!("http://[::1]:{}", port);
+        loop {
+            let client_result = UniverseClient::connect(addr_string.clone()).await;
+            match client_result {
+                Ok(client_ok) => {
+                    client = client_ok;
+                    break;
+                }
+                Err(e) => {
+                    println!("Failed to connect to universe server: {}", e);
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                }
+            }
+        }
+        let session = Arc::new(
+            SessionBuilder::new()
+                .known_node("127.0.0.1:9042".to_string())
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let range_assignment_oracle = Arc::new(RangeAssignmentOracle::new(client));
+        TestContext {
+            range_assignment_oracle,
+            server_shutdown_tx: Some(signal_tx),
+            keyspaces_info,
+            session,
+            cancellation_token: cc_clone,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_full_range_id_of_key() {
+        let context = setup().await;
+        let range_assignment_oracle = context.range_assignment_oracle.clone();
+        let keyspace_info =
+            make_keyspaceinfo("test_keyspace".to_string(), "test_namespace".to_string());
+        context
+            .keyspaces_info
+            .lock()
+            .unwrap()
+            .push(keyspace_info.clone());
+
+        //  Use oracle to get the full range id of a key
+        let key = Bytes::from_static(&[5]);
+        let full_range_id = range_assignment_oracle
+            .full_range_id_of_key(
+                KeyspaceId::new(Uuid::parse_str(&keyspace_info.keyspace_id).unwrap()),
+                key,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            full_range_id.range_id,
+            Uuid::parse_str(&keyspace_info.base_key_ranges[0].base_range_uuid).unwrap()
+        );
+    }
+}

--- a/proto/src/universe.proto
+++ b/proto/src/universe.proto
@@ -4,6 +4,7 @@ package universe;
 service Universe {
     rpc CreateKeyspace (CreateKeyspaceRequest) returns (CreateKeyspaceResponse);
     rpc ListKeyspaces (ListKeyspacesRequest) returns (ListKeyspacesResponse);
+    rpc GetKeyspaceInfo (GetKeyspaceInfoRequest) returns (GetKeyspaceInfoResponse);
 }
 
 enum Cloud {
@@ -62,4 +63,19 @@ message ListKeyspacesRequest {
 
 message ListKeyspacesResponse {
     repeated KeyspaceInfo keyspaces = 1;
+}
+
+message Keyspace {
+    string namespace = 1;
+    string name = 2;
+}
+message GetKeyspaceInfoRequest {
+    oneof keyspace_info_search_field {
+        Keyspace keyspace = 1;
+        string keyspace_id = 2;
+    }
+}
+
+message GetKeyspaceInfoResponse {
+    KeyspaceInfo keyspace_info = 1;
 }

--- a/rangeclient/tests/integration_tests.rs
+++ b/rangeclient/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 use common::{
     config::{
         CassandraConfig, Config, EpochConfig, HostPort, RangeServerConfig, RegionConfig,
-        UniverseConfig,
+        FrontendConfig, UniverseConfig,
     },
     full_range_id::FullRangeId,
     host_info::{HostIdentity, HostInfo},
@@ -60,6 +60,11 @@ fn get_config(warden_address: HostPort) -> Config {
         },
         universe: UniverseConfig {
             proto_server_addr: "127.0.0.1:123".parse().unwrap(),
+        },
+        frontend: FrontendConfig {
+            proto_server_addr: "127.0.0.1:124".parse().unwrap(),
+            fast_network_addr: HostPort::from_str("127.0.0.1:125").unwrap(),
+            transaction_overall_timeout: time::Duration::from_secs(10),
         },
         cassandra: CassandraConfig {
             cql_addr: "127.0.0.1:9042".parse().unwrap(),

--- a/rangeclient/tests/integration_tests.rs
+++ b/rangeclient/tests/integration_tests.rs
@@ -10,8 +10,8 @@ use tokio_util::sync::CancellationToken;
 
 use common::{
     config::{
-        CassandraConfig, Config, EpochConfig, HostPort, RangeServerConfig, RegionConfig,
-        FrontendConfig, UniverseConfig,
+        CassandraConfig, Config, EpochConfig, FrontendConfig, HostPort, RangeServerConfig,
+        RegionConfig, UniverseConfig,
     },
     full_range_id::FullRangeId,
     host_info::{HostIdentity, HostInfo},

--- a/rangeserver/src/config.json
+++ b/rangeserver/src/config.json
@@ -10,6 +10,14 @@
     "universe": {
         "proto_server_addr": "127.0.0.1:50056"
     },
+    "frontend": {
+        "proto_server_addr": "127.0.0.1:50057",
+        "fast_network_addr": "127.0.0.1:50058",
+        "transaction_overall_timeout": {
+            "secs": 10,
+            "nanos": 0
+        }
+    },
     "epoch": {
         "proto_server_addr": "127.0.0.1:50050"
     },

--- a/rangeserver/src/range_manager/impl.rs
+++ b/rangeserver/src/range_manager/impl.rs
@@ -569,8 +569,7 @@ where
 #[cfg(test)]
 mod tests {
     use common::config::{
-        CassandraConfig, EpochConfig, HostPort, RangeServerConfig, FrontendConfig,
-        UniverseConfig,
+        CassandraConfig, EpochConfig, FrontendConfig, HostPort, RangeServerConfig, UniverseConfig,
     };
     use common::transaction_info::TransactionInfo;
     use common::util;

--- a/rangeserver/src/range_manager/impl.rs
+++ b/rangeserver/src/range_manager/impl.rs
@@ -569,7 +569,8 @@ where
 #[cfg(test)]
 mod tests {
     use common::config::{
-        CassandraConfig, EpochConfig, HostPort, RangeServerConfig, UniverseConfig,
+        CassandraConfig, EpochConfig, HostPort, RangeServerConfig, FrontendConfig,
+        UniverseConfig,
     };
     use common::transaction_info::TransactionInfo;
     use common::util;
@@ -725,6 +726,11 @@ mod tests {
             },
             universe: UniverseConfig {
                 proto_server_addr: "127.0.0.1:123".parse().unwrap(),
+            },
+            frontend: FrontendConfig {
+                proto_server_addr: "127.0.0.1:124".parse().unwrap(),
+                fast_network_addr: HostPort::from_str("127.0.0.1:125").unwrap(),
+                transaction_overall_timeout: time::Duration::from_secs(10),
             },
             cassandra: CassandraConfig {
                 cql_addr: HostPort {

--- a/rangeserver/src/server.rs
+++ b/rangeserver/src/server.rs
@@ -742,7 +742,8 @@ pub mod tests {
     use crate::cache::memtabledb::MemTableDB;
     use crate::epoch_supplier::EpochSupplier as Trait;
     use common::config::{
-        CassandraConfig, EpochConfig, HostPort, RangeServerConfig, RegionConfig, UniverseConfig,
+        CassandraConfig, EpochConfig, HostPort, RangeServerConfig, RegionConfig, FrontendConfig,
+        UniverseConfig,
     };
     use common::host_info::HostIdentity;
     use common::network::for_testing::udp_fast_network::UdpFastNetwork;
@@ -813,6 +814,11 @@ pub mod tests {
             },
             universe: UniverseConfig {
                 proto_server_addr: "127.0.0.1:123".parse().unwrap(),
+            },
+            frontend: FrontendConfig {
+                proto_server_addr: HostPort::from_str("127.0.0.1:50056").unwrap(),
+                fast_network_addr: HostPort::from_str("127.0.0.1:50057").unwrap(),
+                transaction_overall_timeout: time::Duration::from_secs(10),
             },
             cassandra: CassandraConfig {
                 cql_addr: "127.0.0.1:9042".parse().unwrap(),

--- a/rangeserver/src/server.rs
+++ b/rangeserver/src/server.rs
@@ -742,7 +742,7 @@ pub mod tests {
     use crate::cache::memtabledb::MemTableDB;
     use crate::epoch_supplier::EpochSupplier as Trait;
     use common::config::{
-        CassandraConfig, EpochConfig, HostPort, RangeServerConfig, RegionConfig, FrontendConfig,
+        CassandraConfig, EpochConfig, FrontendConfig, HostPort, RangeServerConfig, RegionConfig,
         UniverseConfig,
     };
     use common::host_info::HostIdentity;

--- a/universe/src/storage.rs
+++ b/universe/src/storage.rs
@@ -1,4 +1,7 @@
-use proto::universe::{KeyRange, KeyspaceInfo, Zone};
+use proto::universe::{
+    get_keyspace_info_request::KeyspaceInfoSearchField as ProtoKeyspaceInfoSearchField, KeyRange,
+    Keyspace, KeyspaceInfo, Zone,
+};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -12,6 +15,41 @@ pub enum Error {
     KeyspaceAlreadyExists,
     #[error("Storage Layer error: {}", .0.as_ref().map(|e| e.to_string()).unwrap_or_else(|| "Unknown error".to_string()))]
     InternalError(Option<Arc<dyn std::error::Error + Send + Sync>>),
+    #[error("Keyspace does not exist")]
+    KeyspaceDoesNotExist,
+}
+
+#[derive(Debug)]
+pub enum KeyspaceInfoSearchField {
+    Keyspace { namespace: String, name: String },
+    KeyspaceId(String),
+}
+
+impl From<ProtoKeyspaceInfoSearchField> for KeyspaceInfoSearchField {
+    fn from(val: ProtoKeyspaceInfoSearchField) -> Self {
+        match val {
+            ProtoKeyspaceInfoSearchField::Keyspace(keyspace) => KeyspaceInfoSearchField::Keyspace {
+                namespace: keyspace.namespace,
+                name: keyspace.name,
+            },
+            ProtoKeyspaceInfoSearchField::KeyspaceId(keyspace_id) => {
+                KeyspaceInfoSearchField::KeyspaceId(keyspace_id)
+            }
+        }
+    }
+}
+
+impl From<KeyspaceInfoSearchField> for ProtoKeyspaceInfoSearchField {
+    fn from(val: KeyspaceInfoSearchField) -> Self {
+        match val {
+            KeyspaceInfoSearchField::Keyspace { namespace, name } => {
+                ProtoKeyspaceInfoSearchField::Keyspace(Keyspace { namespace, name })
+            }
+            KeyspaceInfoSearchField::KeyspaceId(keyspace_id) => {
+                ProtoKeyspaceInfoSearchField::KeyspaceId(keyspace_id)
+            }
+        }
+    }
 }
 
 pub trait Storage: Send + Sync + 'static {
@@ -28,4 +66,9 @@ pub trait Storage: Send + Sync + 'static {
         &self,
         region: Option<proto::universe::Region>,
     ) -> impl std::future::Future<Output = Result<Vec<KeyspaceInfo>, Error>> + Send;
+
+    fn get_keyspace_info(
+        &self,
+        keyspace_info_search_field: KeyspaceInfoSearchField,
+    ) -> impl std::future::Future<Output = Result<KeyspaceInfo, Error>> + Send;
 }

--- a/warden/src/assignment_computation.rs
+++ b/warden/src/assignment_computation.rs
@@ -457,7 +457,8 @@ mod tests {
     use once_cell::sync::Lazy;
     use proto::universe::{
         universe_server::{Universe, UniverseServer},
-        CreateKeyspaceRequest, CreateKeyspaceResponse, KeyspaceInfo, ListKeyspacesResponse,
+        CreateKeyspaceRequest, CreateKeyspaceResponse, GetKeyspaceInfoRequest,
+        GetKeyspaceInfoResponse, KeyspaceInfo, ListKeyspacesResponse,
     };
     use scylla::{Session, SessionBuilder};
     use tokio::sync::oneshot;
@@ -555,6 +556,13 @@ mod tests {
                         .collect(),
                 }],
             }))
+        }
+
+        async fn get_keyspace_info(
+            &self,
+            _request: Request<GetKeyspaceInfoRequest>,
+        ) -> Result<Response<GetKeyspaceInfoResponse>, Status> {
+            unreachable!()
         }
     }
 


### PR DESCRIPTION
This is **WIP** but opened the PR to easily keep track of changes and discuss about the design.

Changes:
- Introducing `frontend` crate into the `atomix` exosystem (updated Cargo files etc)
- Dumb `RangeAssignmentOracle` implementing only the `full_range_id_of_key` function.
`full_range_id_of_key` accepts a `KeyspaceId` and a `Key` and uses the `KeyspaceId` to get the relevant `KeyspaceInfo` from the `Universe` and then does a linear search on the `base_ranges` of the returned `KeyspaceInfo` to find the one in which the `Key` belongs. From the returned `KeyRange` we construct the `FullRangeInfo`.