### PR TITLE
Rework cache layering

### DIFF
--- a/rangeclient/tests/integration_tests.rs
+++ b/rangeclient/tests/integration_tests.rs
@@ -23,7 +23,6 @@ use common::{
 };
 use rangeclient::client::RangeClient;
 use rangeserver::{
-    cache::memtabledb::MemTableDB,
     for_testing::{epoch_supplier::EpochSupplier, mock_warden::MockWarden},
     server::Server,
 };
@@ -120,7 +119,7 @@ async fn setup_server(
         let config = get_config(warden_address);
         let host_info = get_server_host_info(server_address);
         let bg_runtime = Builder::new_multi_thread().enable_all().build().unwrap();
-        let server = Server::<_, MemTableDB>::new(
+        let server = Server::<_>::new(
             config,
             host_info,
             storage,

--- a/rangeserver/src/main.rs
+++ b/rangeserver/src/main.rs
@@ -69,7 +69,7 @@ fn main() {
             publisher_set.clone(),
             cancellation_token.clone(),
         ));
-        let server = Server::<_, MemTableDB>::new(
+        let server = Server::<_>::new(
             config,
             host_info,
             storage,


### PR DESCRIPTION
It probably makes more sense to do caching as part of storage, as opposed to the RangeManager layer, since different storage implementations might have different caching needs (or have caching built-in)