### PR TITLE
increasing TX ids

### DIFF
--- a/frontend/src/frontend.rs
+++ b/frontend/src/frontend.rs
@@ -11,9 +11,9 @@ use coordinator::{coordinator::Coordinator, keyspace::Keyspace, transaction::Tra
 use tonic::{transport::Server as TServer, Request, Response, Status as TStatus};
 
 use std::net::ToSocketAddrs;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
-
 use tracing::instrument;
 
 use proto::frontend::frontend_server::{Frontend, FrontendServer};
@@ -85,7 +85,11 @@ impl Frontend for ProtoServer {
         println!("Got a request: {:?}", request);
 
         // Generate a new transaction id
-        let transaction_id = Uuid::new_v4();
+        let transaction_id = Uuid::from_u128(
+            self.parent_server
+                .transaction_counter
+                .fetch_add(1, Ordering::SeqCst) as u128,
+        );
         let transaction_info = Arc::new(TransactionInfo {
             id: transaction_id,
             started: Utc::now(),
@@ -365,6 +369,7 @@ pub struct Server {
     //  Keeping track of transactions that haven't committed yet
     transaction_table: RwLock<HashMap<Uuid, Arc<Mutex<Transaction>>>>,
     bg_runtime: tokio::runtime::Handle,
+    transaction_counter: AtomicU64,
 }
 // TODO: add a trait for Frontend?
 impl Server {
@@ -376,6 +381,7 @@ impl Server {
         runtime: tokio::runtime::Handle,
         bg_runtime: tokio::runtime::Handle,
         cancellation_token: CancellationToken,
+        transaction_counter: AtomicU64,
     ) -> Arc<Self> {
         let coordinator = Coordinator::new(
             &config,
@@ -393,6 +399,7 @@ impl Server {
             coordinator,
             transaction_table: RwLock::new(HashMap::new()),
             bg_runtime,
+            transaction_counter: AtomicU64::new(0),
         })
     }
 

--- a/frontend/src/frontend.rs
+++ b/frontend/src/frontend.rs
@@ -399,7 +399,7 @@ impl Server {
             coordinator,
             transaction_table: RwLock::new(HashMap::new()),
             bg_runtime,
-            transaction_counter: AtomicU64::new(0),
+            transaction_counter,
         })
     }
 

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -3,12 +3,12 @@ use common::{
     network::{fast_network::FastNetwork, for_testing::udp_fast_network::UdpFastNetwork},
     region::{Region, Zone},
 };
+use frontend::frontend::Server;
+use std::sync::atomic::AtomicU64;
 use std::{
     net::{ToSocketAddrs, UdpSocket},
     sync::Arc,
 };
-
-use frontend::frontend::Server;
 use tokio::runtime::Builder;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -72,6 +72,7 @@ fn main() {
             runtime_handle,
             bg_runtime_clone,
             ct_clone,
+            AtomicU64::new(0),
         )
         .await;
 

--- a/frontend/tests/integration_tests.rs
+++ b/frontend/tests/integration_tests.rs
@@ -9,17 +9,17 @@ use std::time;
 use uuid::Uuid;
 
 use coordinator::keyspace::Keyspace;
-use once_cell::sync::Lazy;
-use std::collections::HashSet;
-use std::net::UdpSocket;
-use std::sync::Arc;
-use tokio_util::sync::CancellationToken;
-
 use frontend::for_testing::{
     mock_epoch_publisher::MockEpochPublisher, mock_rangeserver::MockRangeServer,
     mock_universe::MockUniverse,
 };
 use frontend::{frontend::Server, range_assignment_oracle::RangeAssignmentOracle};
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+use std::net::UdpSocket;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use proto::frontend::frontend_client::FrontendClient;
@@ -170,6 +170,7 @@ async fn setup() -> TestContext {
             RUNTIME.handle().clone(),
             RUNTIME.handle().clone(),
             cancellation_token.clone(),
+            AtomicU64::new(0),
         )
         .await;
         Server::start(server).await;


### PR DESCRIPTION
- Switched transaction IDs to increasing numbers instead of random ones.
- This has a couple of issues:
  - IDs are not persisted so if frontend restarts it will start assigning IDs starting from 0 again
  - IDs not globally unique if we have more than one `frontend` servers
  - Most importantly, this change does not solve the crash caused by the lock prevention (`wait_die`) in the `lock_table.rs`. IDs are assigned when the transaction starts but locks are being held when we get/put. So it's possible that TX with id 2 tries to hold locks before TX with id 1. Most transactions are gonna get rejected this way, no? Also to avoid the crash I suppose we need better error handling in the `frontend` and some tooling to retry aborted transactions?

For now I will keep the lock prevention disabled but will revisit this soon.