### PR TITLE
Commit transactions by id only

### DIFF
--- a/rangeserver/src/range_manager.rs
+++ b/rangeserver/src/range_manager.rs
@@ -54,7 +54,7 @@ pub trait RangeManager {
     /// idempotent and safe to retry any number of times.
     async fn commit(
         &self,
-        tx: Arc<TransactionInfo>,
+        tx_id: Uuid,
         commit: CommitRequest<'_>,
     ) -> Result<(), Error>;
 }

--- a/rangeserver/src/range_manager/lock_table.rs
+++ b/rangeserver/src/range_manager/lock_table.rs
@@ -1,6 +1,7 @@
 use crate::{error::Error, transaction_abort_reason::TransactionAbortReason};
 use chrono::DateTime;
 use common::transaction_info::TransactionInfo;
+use uuid::Uuid;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::oneshot;
@@ -126,11 +127,11 @@ impl LockTable {
         }
     }
 
-    pub async fn is_currently_holding(&self, tx: Arc<TransactionInfo>) -> bool {
+    pub async fn is_currently_holding(&self, tx_id : Uuid) -> bool {
         let state = self.state.read().await;
         match &state.current_holder {
             None => false,
-            Some(current) => current.transaction.id == tx.id,
+            Some(current) => current.transaction.id == tx_id,
         }
     }
 }

--- a/rangeserver/src/server.rs
+++ b/rangeserver/src/server.rs
@@ -477,8 +477,7 @@ where
             Some(id) => util::flatbuf::deserialize_uuid(id),
         };
         let rm = self.maybe_load_and_get_range(&range_id).await?;
-        let tx = self.get_transaction_info(transaction_id).await?;
-        rm.commit(tx.clone(), request).await?;
+        rm.commit(transaction_id, request).await?;
         self.remove_transaction(transaction_id).await;
         Ok(())
     }


### PR DESCRIPTION
We don't need to look up the transaction info to record transaction commit.

Fixes #36 